### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - 'scripts/**'
       - '.github/workflows/test.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-patches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/amoyrtil/talos-ufs/security/code-scanning/1](https://github.com/amoyrtil/talos-ufs/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that scopes down the `GITHUB_TOKEN` to the minimal privileges needed. Since this workflow only checks out code and queries public releases via `gh api`, it does not need write access; `contents: read` is sufficient, and no other scopes (like `pull-requests`, `issues`, etc.) are required.

The best way to fix this without changing functionality is to define `permissions` at the workflow root (top level), so it applies to all jobs unless overridden. Add a `permissions:` section directly under the `name:` (or just after `on:` if you prefer) with `contents: read`. This ensures both `validate-patches` and `build-kernel` jobs use a read‑only token. No other changes to steps, environment variables, or commands are needed, and no additional imports or external dependencies are involved.

Concretely: edit `.github/workflows/test.yml` to insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after the `on:` block). This will satisfy CodeQL’s requirement and enforce least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
