### PR TITLE
Parameterize clone versions and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
-/.tmp
-/output
+/tmp

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ docker buildx create --name talos-builder --driver docker-container \
   --driver-opt network=host --config /tmp/buildkitd.toml --use
 
 # 3. Clone repositories
-git clone --branch release-1.12 https://github.com/siderolabs/pkgs.git /tmp/pkgs
-git clone --branch v1.12.2 https://github.com/siderolabs/talos.git /tmp/talos
+git clone --branch <talos-version> https://github.com/siderolabs/talos.git /tmp/talos
+# Resolve pkgs version: grep '^PKGS ?=' /tmp/talos/Makefile
+git clone --branch <pkgs-version> https://github.com/siderolabs/pkgs.git /tmp/pkgs
 
 # 4. Apply patches
 ./scripts/apply-patches.sh /tmp/pkgs /tmp/talos


### PR DESCRIPTION
Change .gitignore to ignore /tmp (remove /.tmp and /output). Update README clone steps to use placeholders (<talos-version>, <pkgs-version>), add a note to resolve the pkgs version from the talos Makefile (grep '^PKGS ?=' /tmp/talos/Makefile), and clone talos before pkgs so the pkgs version can be determined. These edits make the build instructions more flexible and clarify how to pick the correct pkgs branch.