### PR TITLE
Add upstream release notes link to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,6 +273,8 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --title "Talos Linux ${{ inputs.talos_version }} with UFS Support" \
             --notes "$(cat <<'NOTES_EOF'
+          **Upstream Release Notes:** https://github.com/siderolabs/talos/releases/tag/${{ inputs.talos_version }}
+
           ## Downloads
 
           - `metal-amd64.iso` - USB boot installation media


### PR DESCRIPTION
Include a link to the upstream Talos release notes in the release body generated by the CI. The build workflow (.github/workflows/build.yml) now inserts an "Upstream Release Notes" URL using the inputs.talos_version variable so generated releases reference the original upstream changelog.