### PR TITLE
fix(ci): pre-create _out before make installer (fixes #10)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,7 @@ jobs:
         if: steps.check-talos.outputs.exists == 'false'
         working-directory: /tmp/talos
         run: |
+          mkdir -p _out
           make imager \
             PKG_KERNEL="${{ needs.build-kernel.outputs.kernel_image }}" \
             PLATFORM=linux/amd64 \
@@ -189,6 +190,7 @@ jobs:
         if: steps.check-talos.outputs.exists == 'false'
         working-directory: /tmp/talos
         run: |
+          mkdir -p _out
           make installer-base \
             PKG_KERNEL="${{ needs.build-kernel.outputs.kernel_image }}" \
             PLATFORM=linux/amd64 \
@@ -202,6 +204,9 @@ jobs:
         env:
           CRANE_INSECURE: "true"
         run: |
+          # Talos v1.13+ runs imager as host user (--user $(id -u):$(id -g)).
+          # Pre-create _out so the docker volume mount doesn't auto-create it as root.
+          mkdir -p _out
           make installer \
             PKG_KERNEL="${{ needs.build-kernel.outputs.kernel_image }}" \
             PLATFORM=linux/amd64 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,10 @@ git clone https://github.com/siderolabs/pkgs.git /tmp/pkgs
 make -C /tmp/pkgs kernel PLATFORM=linux/amd64 PUSH=true REGISTRY=localhost:5000 USERNAME=siderolabs
 
 # Build Talos images (in /tmp/talos) — uses INSTALLER_ARCH, PKG_KERNEL, etc.
+# Pre-create _out before `make installer`: Talos v1.13+ runs the imager
+# container with --user $(id -u):$(id -g), so a docker-auto-created _out
+# (owned by root) breaks the installer tarball write.
+mkdir -p /tmp/talos/_out
 # See README.md "Local Build" section for exact make targets and arguments
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ docker buildx build --no-cache --file=Pkgfile --platform=linux/amd64 \
 
 # 6. Build imager, installer-base, and installer
 cd /tmp/talos
+
+# Pre-create the artifacts directory. Talos v1.13+ runs the imager container as
+# the host user (--user $(id -u):$(id -g)); if _out is auto-created by the
+# docker volume mount it will be owned by root and the installer build will
+# fail with "permission denied" when writing installer-<arch>.tar.
+mkdir -p _out
+
 gmake imager \
   PKG_KERNEL=host.docker.internal:5005/siderolabs/kernel:custom \
   PLATFORM=linux/amd64 REGISTRY=localhost:5005 PUSH=true INSTALLER_ARCH=amd64
@@ -176,6 +183,10 @@ Docker Buildx may cache kernel build layers. Always use `--no-cache` when buildi
 ### "TLS config specified for non-HTTPS registry"
 
 When using a local HTTP registry, only configure `mirrors` in machine config. Do not add `config.tls.insecureSkipVerify` for HTTP registries.
+
+### `make installer` fails with `open /out/installer-<arch>.tar: permission denied`
+
+Talos v1.13 changed the `image-%` Makefile target to run the imager container with `--user $(id -u):$(id -g)` (instead of `--privileged`). If `_out` does not exist beforehand, Docker auto-creates it as `root` via the volume mount, and the container running as the host user cannot write to it. `mkdir -p _out` in the Talos source directory before invoking `make installer` resolves the issue.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Talos v1.13 changed the `image-%` Makefile target to run the imager container with `--user $(id -u):$(id -g)` instead of `--privileged`. When `_out` does not exist beforehand, Docker auto-creates it as `root` via the volume mount, and the host-user container fails to write `installer-<arch>.tar` with `permission denied`.
- Pre-create `_out` before each `make` step in `build-talos` (`imager`, `installer-base`, `installer`). Only `installer` is the actually failing target today, but the other two are added defensively in case upstream extends `_out` usage in future versions.
- Update `README.md` (Local Build + Troubleshooting) and `CLAUDE.md` (Local Build) with the same requirement.

## Root cause analysis

The v1.13.3 build (run [26490660342](https://github.com/amoyrtil/talos-ufs/actions/runs/26490660342)) failed with:

```
failed to write image tarball: open /out/installer-amd64.tar: permission denied
```

Upstream diff between v1.12.8 (last successful) and v1.13.x:

```diff
 image-%:
 	@docker pull ...
 	@for platform ...; do
-		docker run --rm -t ... --privileged ...
+		docker run --rm -t ... --user $(shell id -u):$(shell id -g) ...
 			-v $(PWD)/$(ARTIFACTS):/out ...
 	done
```

Neither `installer:` nor `image-%:` depends on `$(ARTIFACTS)`, so `_out` is not created by make. Docker's volume mount auto-creates the missing host path as `root`, then the UID 1001 container fails.

## Test plan

- [ ] Trigger the `Build Talos UFS` workflow with `talos_version=v1.13.3` and confirm the `Build installer to local registry` step succeeds
- [ ] Confirm the resulting ISO is published as a release and `verify-build.sh` passes
- [ ] Confirm patch-failure issue #10 auto-closes on successful build

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)