### PR TITLE
ci: bump actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       kernel_image: ${{ steps.meta.outputs.kernel_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone siderolabs/talos
         run: |
@@ -63,10 +63,10 @@ jobs:
           git -C /tmp/pkgs apply --3way "${{ github.workspace }}/patches/kernel-config.patch"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
       installer_image: ${{ steps.meta.outputs.installer_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set image tags
         id: meta
@@ -159,7 +159,7 @@ jobs:
 
       - name: Set up Docker Buildx (with insecure local registry)
         if: steps.check-talos.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           buildkitd-config-inline: |
             [registry."localhost:5000"]
@@ -168,7 +168,7 @@ jobs:
           driver-opts: network=host
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -252,10 +252,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest Talos release tag
         id: talos-version
@@ -79,7 +79,7 @@ jobs:
       github.event.pull_request.changed_files > 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.patches_changed == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build kernel (compilation test)
         if: steps.changes.outputs.patches_changed == 'true'


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions to versions that run on Node.js 24, resolving the Node.js 20 deprecation warning
- `actions/checkout`: v4 → v6
- `docker/login-action`: v3 → v4
- `docker/setup-buildx-action`: v3 → v4

Node.js 20 will be forced to Node.js 24 on June 16, 2026 and removed entirely on September 16, 2026. All updated actions are at their latest major version, where v6.0.0 / v4.0.0 introduced Node.js 24 as the default runtime.

Closes #12

## Test plan
- [ ] `test.yml` runs successfully on this PR (validates patches apply cleanly)
- [ ] No new deprecation warnings appear in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)