### PR TITLE
Fix local image tag resolution for monorepo tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,9 +218,13 @@ jobs:
         if: steps.check-talos.outputs.exists == 'false'
         id: local-tag
         run: |
-          # Talos appends -dirty when source is modified
+          # Match Talos's own Makefile tag logic (TAG := git describe --tag
+          # --always --dirty --match v[0-9]\*). Without --match, describe can
+          # resolve to a monorepo tag like pkg/machinery/v1.13.5, whose slashes
+          # are an invalid Docker reference and don't match the pushed image.
+          # Talos appends -dirty when source is modified.
           cd /tmp/talos
-          TAG=$(git describe --tag --always --dirty 2>/dev/null || echo "${{ inputs.talos_version }}-dirty")
+          TAG=$(git describe --tag --always --dirty --match 'v[0-9]*' 2>/dev/null || echo "${{ inputs.talos_version }}-dirty")
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Local image tag: ${TAG}"
 


### PR DESCRIPTION
## Cause (Fixes #17)

The v1.13.5 build failed at the "Push images to GHCR with project naming" step:

```
Invalid source name docker://localhost:5000/siderolabs/imager:pkg/machinery/v1.13.5-dirty: invalid reference format
```

The `Determine local image tag` step ran `git describe --tag --always --dirty` without a `--match` filter. The v1.13.5 commit carries both a `v1.13.5` and a `pkg/machinery/v1.13.5` tag, and describe resolved to the latter. Its slashes make it an invalid Docker reference, and it also doesn't match the tag Talos actually pushes (`v1.13.5-dirty`).

Verification:
```
without match: pkg/machinery/v1.13.5
with match:    v1.13.5
```

## Fix

Add the same `--match 'v[0-9]*'` filter that Talos's own Makefile uses (`TAG := git describe --tag --always --dirty --match v[0-9]\*`), so the resolved local tag stays in sync with the pushed image.

## Impact

- Single-line change in `.github/workflows/build.yml` (patches and scripts untouched).
- The imager/installer GHCR push now succeeds, unblocking the downstream ISO generation, release creation, and auto-close of the patch-failure issue.
- `--match 'v[0-9]*'` mirrors Talos's canonical logic, so it remains backward compatible across other versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)