### PR TITLE
Authenticate crane release lookup to avoid rate-limit 404

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,8 +148,19 @@ jobs:
 
       - name: Install crane
         if: steps.check-talos.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r .tag_name)
+          # Authenticate the API call: unauthenticated requests from shared
+          # Actions runners hit the 60/hr rate limit and return JSON without
+          # .tag_name, leaving VERSION=null and a 404 download URL.
+          VERSION=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r .tag_name)
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "Failed to resolve latest crane version" >&2
+            exit 1
+          fi
+          echo "Installing crane ${VERSION}"
           curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin crane
 
       - name: Start local registry


### PR DESCRIPTION
## Cause

After merging #18, the v1.13.5 build (run 28278338337) failed at a different step — `Install crane`:

```
curl: (22) The requested URL returned error: 404
gzip: stdin: unexpected end of file
tar: Child returned status 1
```

The step queried the go-containerregistry releases API **unauthenticated**:

```bash
VERSION=$(curl -s https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r .tag_name)
```

Shared GitHub Actions runners frequently exhaust the 60 req/hr unauthenticated `api.github.com` limit. When rate-limited the API returns `{"message": ...}` with no `.tag_name`, so `jq -r .tag_name` yields `null`, the download URL becomes `.../download/null/go-containerregistry_Linux_x86_64.tar.gz`, and curl gets a 404.

(Verified the release/asset are fine from an unthrottled host: latest tag is `v0.21.7` and `go-containerregistry_Linux_x86_64.tar.gz` exists — so this is purely a rate-limit issue, not an upstream rename.)

## Fix

- Authenticate the API request with `GITHUB_TOKEN` (raises the limit to 1000 req/hr), preserving the existing "track latest crane" behavior.
- Fail fast with a clear message if the version can't be resolved, instead of producing a misleading 404.

## Impact

- Single-step change in `.github/workflows/build.yml`; patches and scripts untouched.
- Unblocks the `build-talos` job so the pipeline can reach the (already fixed in #18) image push and downstream ISO/release steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)