### PR TITLE
fix(ci): address CI review findings (#1–#6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       kernel_image: ${{ steps.meta.outputs.kernel_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Clone siderolabs/talos
         run: |
@@ -63,10 +63,10 @@ jobs:
           git -C /tmp/pkgs apply --3way "${{ github.workspace }}/patches/kernel-config.patch"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
       installer_image: ${{ steps.meta.outputs.installer_image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set image tags
         id: meta
@@ -124,7 +124,7 @@ jobs:
           echo "installer_image=${INSTALLER_IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Set up Docker Buildx (with insecure local registry)
         if: steps.check-talos.outputs.exists == 'false'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           buildkitd-config-inline: |
             [registry."localhost:5000"]
@@ -269,10 +269,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,6 +292,10 @@ jobs:
           cd output
           sha256sum metal-amd64.iso > metal-amd64.iso.sha256
 
+      - name: Verify UFS drivers in ISO
+        run: |
+          ./scripts/verify-build.sh output/metal-amd64.iso
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ inputs.talos_version }}-ufs"
-          OWNER="${{ github.repository_owner }}"
 
           gh release create "${TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
@@ -322,9 +321,9 @@ jobs:
           ## Container Images
 
           ```
-          ghcr.io/OWNER_PLACEHOLDER/talos-ufs-installer:VERSION_PLACEHOLDER
-          ghcr.io/OWNER_PLACEHOLDER/talos-ufs-imager:VERSION_PLACEHOLDER
-          ghcr.io/OWNER_PLACEHOLDER/talos-ufs-kernel:VERSION_PLACEHOLDER
+          ghcr.io/${{ github.repository_owner }}/talos-ufs-installer:${{ inputs.talos_version }}
+          ghcr.io/${{ github.repository_owner }}/talos-ufs-imager:${{ inputs.talos_version }}
+          ghcr.io/${{ github.repository_owner }}/talos-ufs-kernel:${{ inputs.talos_version }}
           ```
 
           ## Installation
@@ -336,14 +335,14 @@ jobs:
              ```yaml
              machine:
                install:
-                 image: ghcr.io/OWNER_PLACEHOLDER/talos-ufs-installer:VERSION_PLACEHOLDER
+                 image: ghcr.io/${{ github.repository_owner }}/talos-ufs-installer:${{ inputs.talos_version }}
              ```
 
           ## Custom ISO Generation
 
           ```bash
           docker run --rm -t -v /dev:/dev --privileged \
-            ghcr.io/OWNER_PLACEHOLDER/talos-ufs-imager:VERSION_PLACEHOLDER \
+            ghcr.io/${{ github.repository_owner }}/talos-ufs-imager:${{ inputs.talos_version }} \
             metal --system-extension-image <extension-image>
           ```
 
@@ -357,12 +356,6 @@ jobs:
           )" \
             output/metal-amd64.iso \
             output/metal-amd64.iso.sha256
-
-          # Replace placeholders in release notes
-          gh release edit "${TAG}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --notes "$(gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json body --jq .body | \
-              sed "s/OWNER_PLACEHOLDER/${OWNER}/g; s/VERSION_PLACEHOLDER/${{ inputs.talos_version }}/g")"
 
       - name: Auto-close patch failure issues
         if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,18 @@ jobs:
           echo "imager_image=${IMAGER_IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
           echo "installer_image=${INSTALLER_IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if talos images already exist
         id: check-talos
         run: |
+          # skopeo reads ~/.docker/config.json, so the GHCR login above lets it
+          # inspect the project's private packages instead of always missing.
           if skopeo inspect "docker://${IMAGER_IMAGE}:${{ inputs.talos_version }}" &>/dev/null && \
              skopeo inspect "docker://${INSTALLER_IMAGE}:${{ inputs.talos_version }}" &>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -177,13 +186,6 @@ jobs:
               http = true
               insecure = true
           driver-opts: network=host
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build imager to local registry
         if: steps.check-talos.outputs.exists == 'false'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
         type: string
 
 concurrency:
-  group: build-${{ github.workflow }}
-  cancel-in-progress: true
+  group: build-${{ github.workflow }}-${{ inputs.talos_version }}
+  cancel-in-progress: false
 
 env:
   KERNEL_IMAGE: ghcr.io/${{ github.repository_owner }}/talos-ufs-kernel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Get latest Talos release tag
         id: talos-version
@@ -78,7 +78,7 @@ jobs:
     if: contains(github.event.pull_request.title, '[full-test]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -128,7 +128,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.patches_changed == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build kernel (compilation test)
         if: steps.changes.outputs.patches_changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,10 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     needs: validate-patches
-    # Only run kernel build when patch files actually changed
-    if: |
-      contains(github.event.pull_request.title, '[full-test]') ||
-      github.event.pull_request.changed_files > 0
+    # Full 6h kernel build is opt-in: requires '[full-test]' in the PR title.
+    # The inner "Check if patches changed" step further skips it unless patches/ changed.
+    if: contains(github.event.pull_request.title, '[full-test]')
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Addresses six CI/workflow issues found in review of `build.yml` and `test.yml`. Each is its own commit.

| # | Change |
|---|--------|
| 1 | **Require `[full-test]` for kernel build test** — the `build-kernel` `if` used an OR with `changed_files > 0` (true on nearly every PR), making `[full-test]` a no-op. Now gated on `[full-test]` only; the inner "patches changed" step still applies, matching the documented "patches changed AND `[full-test]`" contract. |
| 2 | **Log in to GHCR before the image existence check** in `build-talos` — the unauthenticated `skopeo inspect` always failed against private packages, forcing a full 2h rebuild every run. |
| 3 | **Verify UFS drivers in the ISO before publishing** — `scripts/verify-build.sh` now runs as a release gate (previously never executed in CI). |
| 4 | **Inline release-note template vars** — drop `OWNER_PLACEHOLDER`/`VERSION_PLACEHOLDER` and the `gh release edit ... sed` second pass; `${{ }}` is expanded by Actions even in a quoted heredoc. |
| 5 | **Scope build concurrency per version** + `cancel-in-progress: false` so a new dispatch can't cancel an in-progress multi-hour build for a different version. |
| 6 | **Pin third-party actions to commit SHA** (`actions/checkout`, `docker/setup-buildx-action`, `docker/login-action`) with version comments for Renovate. |

## Testing

- Both workflow YAMLs parse cleanly; shell scripts pass `bash -n`.
- No real build (6–8h) was run; changes are logic/syntax level.
- `actionlint` was not available locally, so only static review + YAML parse were performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)