### PR TITLE
Fix verify-build.sh docker mount with relative ISO path

### DIFF
--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -16,6 +16,10 @@ if [ ! -f "${ISO_PATH}" ]; then
   exit 1
 fi
 
+# Docker requires an absolute path for bind mounts; a relative path is
+# interpreted as a named volume and rejected with "invalid characters".
+ISO_PATH="$(cd "$(dirname "${ISO_PATH}")" && pwd)/$(basename "${ISO_PATH}")"
+
 echo "Verifying UFS drivers in ${ISO_PATH}..."
 
 RESULT=$(docker run --rm --privileged --platform linux/amd64 \


### PR DESCRIPTION
## Problem

The `generate-iso` job's **Verify UFS drivers in ISO** step fails with exit code 125:

```
docker: Error response from daemon: create output/metal-amd64.iso:
"output/metal-amd64.iso" includes invalid characters for a local volume name,
only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host
directory, use absolute path
```

`build.yml` invokes `./scripts/verify-build.sh output/metal-amd64.iso` with a **relative** path, which the script forwards to `docker run -v "${ISO_PATH}:/iso:ro"`. Docker interprets a relative path as a named volume and rejects it. ISO generation and checksum steps succeed — only verification breaks.

Failing run: https://github.com/amoyrtil/talos-ufs/actions/runs/29137902602/job/86505667442

## Fix

Resolve `ISO_PATH` to an absolute path in `verify-build.sh` before the bind mount.

## Testing

- `bash -n scripts/verify-build.sh` passes
- Path-resolution logic verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)