### PR TITLE
Verify UFS drivers via userspace ISO extraction (xorriso), not loop mount

### DIFF
--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -22,13 +22,17 @@ ISO_PATH="$(cd "$(dirname "${ISO_PATH}")" && pwd)/$(basename "${ISO_PATH}")"
 
 echo "Verifying UFS drivers in ${ISO_PATH}..."
 
-RESULT=$(docker run --rm --privileged --platform linux/amd64 \
+RESULT=$(docker run --rm --platform linux/amd64 \
   -v "${ISO_PATH}:/iso:ro" alpine:latest sh -c "
-apk add --no-cache cpio zstd squashfs-tools 2>/dev/null >/dev/null
-mkdir -p /tmp/iso /tmp/work /tmp/sqsh
-mount -t iso9660 -o loop,ro /iso /tmp/iso
+apk add --no-cache xorriso cpio zstd squashfs-tools 2>/dev/null >/dev/null
+mkdir -p /tmp/work /tmp/sqsh
+# Extract the initramfs from the ISO in userspace with xorriso/osirrox.
+# A loop mount would need a host iso9660 kernel module + CAP_SYS_ADMIN,
+# which is unreliable on CI runners; xorriso reads the ISO9660 image
+# directly with no mount, no loop device, and no privileged container.
+osirrox -indev /iso -extract /boot/initramfs.xz /tmp/initramfs.xz 2>/dev/null
 cd /tmp/work
-zstd -dc /tmp/iso/boot/initramfs.xz | cpio -idm 2>/dev/null
+zstd -dc /tmp/initramfs.xz | cpio -idm 2>/dev/null
 unsquashfs -d /tmp/sqsh rootfs.sqsh 'usr/lib/modules/*/modules.builtin' 2>/dev/null
 grep -i ufs /tmp/sqsh/usr/lib/modules/*/modules.builtin || true
 ")

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -26,7 +26,7 @@ RESULT=$(docker run --rm --privileged --platform linux/amd64 \
   -v "${ISO_PATH}:/iso:ro" alpine:latest sh -c "
 apk add --no-cache cpio zstd squashfs-tools 2>/dev/null >/dev/null
 mkdir -p /tmp/iso /tmp/work /tmp/sqsh
-mount -o loop,ro /iso /tmp/iso
+mount -t iso9660 -o loop,ro /iso /tmp/iso
 cd /tmp/work
 zstd -dc /tmp/iso/boot/initramfs.xz | cpio -idm 2>/dev/null
 unsquashfs -d /tmp/sqsh rootfs.sqsh 'usr/lib/modules/*/modules.builtin' 2>/dev/null


### PR DESCRIPTION
## Problem

After #25 fixed the relative-path error (exit 125), the re-run ([run 29139105956](https://github.com/amoyrtil/talos-ufs/actions/runs/29139105956)) reached the loop mount and failed with exit 1:

```
mount: mounting /dev/loop0 on /tmp/iso failed: Invalid argument
zstd: can't stat /tmp/iso/boot/initramfs.xz : No such file or directory
FAIL: ufshcd-core NOT found in modules.builtin
```

This verification step was added recently and had never run to completion — the relative-path bug always failed first, masking this second issue.

## Why not just `mount -t iso9660`

A loop mount inside the container depends on the **host** kernel providing the `iso9660` module and on `CAP_SYS_ADMIN` / `--privileged`. Per [GitHub's runner docs and community reports](https://docs.github.com/en/actions/reference/runners/github-hosted-runners), loop-mount behavior on hosted runners is environment-dependent, and I could not faithfully reproduce the runner's kernel state locally (locally the no-`-t` mount even succeeded). Relying on it would be an unverified guess.

## Fix

Extract the initramfs from the ISO in **userspace with xorriso/osirrox** — no mount syscall, no loop device, no kernel module, no privileged container. This removes the runner-environment dependency entirely.

## Testing

Generated a real `v1.13.6` ISO locally from `ghcr.io/amoyrtil/talos-ufs-imager:v1.13.6` and ran the full script against it:

```
PASS: ufshcd-core found in modules.builtin
PASS: ufshcd-pci found in modules.builtin
All UFS driver checks passed.
```

`bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)